### PR TITLE
Don't install full git stack on debian

### DIFF
--- a/tasks/debian.yml
+++ b/tasks/debian.yml
@@ -4,7 +4,7 @@
   with_items:
     - make
     - gcc
-    - git-all
+    - git
     - wget
     - curl
     - patch


### PR DESCRIPTION
Like on centos, you don't need git-all on debian.