### PR TITLE
Added dependency on libc6-dev

### DIFF
--- a/tasks/debian.yml
+++ b/tasks/debian.yml
@@ -9,3 +9,4 @@
     - curl
     - patch
     - sudo
+    - libc6-dev


### PR DESCRIPTION
Added a small fix that makes it so `libc6-dev` is installed. This should resolve #2 .