### PR TITLE
Removed the usage of looping constructs

### DIFF
--- a/tasks/debian.yml
+++ b/tasks/debian.yml
@@ -1,12 +1,13 @@
 - name: install dependencies package - Debian
-  package: name={{ item }} state=present
   become: yes
-  with_items:
-    - make
-    - gcc
-    - git
-    - wget
-    - curl
-    - patch
-    - sudo
-    - libc6-dev
+  package:
+    state: present
+    name:
+      - make
+      - gcc
+      - git
+      - wget
+      - curl
+      - patch
+      - sudo
+      - libc6-dev

--- a/tasks/redhat.yml
+++ b/tasks/redhat.yml
@@ -1,24 +1,26 @@
 - name: install dependencies package - RedHat, except Fedora
   when: ansible_distribution != 'Fedora'
-  yum: name={{ item }} state=installed
   become: yes
-  with_items:
-    - perl-ExtUtils-MakeMaker
-    - make
-    - gcc
-    - git
-    - wget
-    - patch
+  package:
+    state: installed
+    name:
+      - perl-ExtUtils-MakeMaker
+      - make
+      - gcc
+      - git
+      - wget
+      - patch
 
 - name: install dependencies package - RedHat, distro Fedora
   when: ansible_distribution == 'Fedora'
-  dnf: name={{ item }} state=latest
   become: yes
-  with_items:
-    - perl-ExtUtils-MakeMaker
-    - make
-    - gcc
-    - git-all
-    - wget
-    - patch
-    - tar
+  package:
+    state: latest
+    name:
+      - perl-ExtUtils-MakeMaker
+      - make
+      - gcc
+      - git-all
+      - wget
+      - patch
+      - tar


### PR DESCRIPTION
As part of this pull request I have changed package installation in *both* RedHat/Fedora and Debian tasks. I have also removed the usage of the `yum` role from the RedHat/Fedora task. This last change is something that can be debated if is sensible or not, but given that the package module should be able to auto-detect the correct package manager to use I think it should be fine.

Another thing: I have only tested this for Debian as that is what I have convenient access to.

Runtime for the package installation task here on Debian was reduced from a steady 11s to 1.35s on average.

This should resolve #6 .