### PR TITLE
Let root own /etc/profile.d/plenv.sh and let anyone execute it

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -39,7 +39,7 @@
   become_user: "{{ plenv.user }}"
 
 - name: set profile.d
-  template: src=plenv.sh.j2 dest=/etc/profile.d/plenv.sh owner="{{ plenv.user }}" mode=744
+  template: src=plenv.sh.j2 dest=/etc/profile.d/plenv.sh owner=root mode=755
   become: yes
 
 - name: exist version


### PR DESCRIPTION
Might not be the absolute best solution, but should solve the ownership-flipping. Would resolve #8 .